### PR TITLE
プロフィール画像の修正

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -4,7 +4,9 @@ class ProfilesController < ApplicationController
 
   def show; end
 
-  def edit; end
+  def edit
+    @user.build_profile_image unless @user.profile_image
+  end
 
   def update
     if @user.update(user_params)
@@ -22,6 +24,9 @@ class ProfilesController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:name, :email, :avatar)
+    params.require(:user).permit(
+      :name, :email,
+      profile_image_attributes: [:id, :avatar]
+    )
   end
 end

--- a/app/models/profile_image.rb
+++ b/app/models/profile_image.rb
@@ -1,0 +1,4 @@
+class ProfileImage < ApplicationRecord
+  belongs_to :user
+  has_one_attached :avatar
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,8 +8,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :plans, dependent: :destroy
-
-  has_one_attached :avatar
+  has_one :profile_image, dependent: :destroy
+  accepts_nested_attributes_for :profile_image
 
   def own?(object)
     object&. user_id == id

--- a/app/views/plans/_plan.html.erb
+++ b/app/views/plans/_plan.html.erb
@@ -25,8 +25,8 @@
           <span>東京都</span>
         </div>
         <div class='flex ml-2'>
-          <% if plan.user.avatar.present? %>
-            <%= image_tag(plan.user.avatar, class: 'w-6 h-6 rounded-full') %>
+          <% if plan.user.profile_image&.avatar&.attached? %>
+            <%= image_tag(plan.user.profile_image.avatar, class: 'w-6 h-6 rounded-full') %>
           <% else %>
             <%= image_tag('sample.jpeg', class: 'w-6 h-6 rounded-full') %>
           <% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -3,16 +3,18 @@
   <%= form_with model: @user, url: profile_path, data: { turbo_method: :put }, local: true do |f| %>
 
     <div class='pt-10 sm:mx-32'>
-      <%= f.label :avatar %>
-      <div class='flex'>
-        <%= f.file_field :avatar, direct_upload: true, class: 'w-full file-input border-none custom-file-input' %>
-      </div>
+      <%= f.fields_for :profile_image do |profile_image_form| %>
+  <%= profile_image_form.label :avatar %>
+  <div class='flex'>
+    <%= profile_image_form.file_field :avatar, direct_upload: true, class: 'w-full file-input border-none custom-file-input' %>
+  </div>
+<% end %>
     </div>
     <div class='sm:mx-32'>
-      <% if current_user.avatar.present? %>
+      <% if current_user.profile_image&.avatar&.attached? %>
         <p>現在の画像</p>
         <div>
-          <%= image_tag current_user.avatar, class: 'w-32 h-32 rounded-lg' %>
+          <%= image_tag current_user.profile_image.avatar, class: 'w-32 h-32 rounded-lg' %>
         </div>
       <% end %>
     </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,8 +2,8 @@
   <h1 class='text-accent-blue font-bold pt-4 pb-5 mb-5 mx-auto text-center text-xl'><%= t('.title') %></h1>
   <div class='text-center'>
     <div>
-      <% if current_user.avatar.present? %>
-        <%= image_tag(current_user.avatar, class: 'my-0 mx-auto w-32 h-32 rounded-full') %>
+      <% if current_user.profile_image&.avatar&.attached? %>
+        <%= image_tag(current_user.profile_image.avatar, class: 'my-0 mx-auto w-32 h-32 rounded-full') %>
       <% else %>
         <%= image_tag('sample.jpeg', class: 'my-0 mx-auto w-32 h-32 rounded-full') %>
       <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,8 +6,8 @@
     <div class='flex'>
       <%= link_to profile_path, class: 'mr-12' do %>
         <div class='cursor-pointer sm:hidden'>
-          <% if current_user.avatar.present? %>
-            <%= image_tag(current_user.avatar, class: 'w-7 h-7 rounded-full') %>
+          <% if current_user.profile_image&.avatar&.attached? %>
+            <%= image_tag(current_user.profile_image.avatar, class: 'w-7 h-7 rounded-full') %>
           <% else %>
             <%= image_tag('sample.jpeg', class: 'w-7 h-7 rounded-full') %>
           <% end %>
@@ -26,8 +26,8 @@
           <li>
           <%= link_to '#' do %>
             <div class='flex'>
-              <% if current_user.avatar.present? %>
-                <%= image_tag(current_user.avatar, class: 'my-0 mx-auto w-8 h-8 rounded-full') %>
+              <% if current_user.profile_image&.avatar&.attached? %>
+                <%= image_tag current_user.profile_image.avatar, class: 'my-0 mx-auto w-8 h-8 rounded-full' %>
               <% else %>
                 <%= image_tag('sample.jpeg', class: 'my-0 mx-auto w-8 h-8 rounded-full') %>
               <% end %>
@@ -48,8 +48,8 @@
         <ul>
           <li class='mt-6 translate-y-4 transition-opacity transition-transform animate-tracking-in-expand-fwd-bottom'>
           <%= link_to profile_path do %>
-            <% if current_user.avatar.present? %>
-              <%= image_tag(current_user.avatar, class: 'my-0 mx-auto w-16 h-16 rounded-full') %>
+            <% if current_user.profile_image&.avatar&.attached? %>
+              <%= image_tag(current_user.profile_image.avatar, class: 'my-0 mx-auto w-16 h-16 rounded-full') %>
             <% else %>
               <%= image_tag('sample.jpeg', class: 'my-0 mx-auto w-16 h-16 rounded-full') %>
             <% end %>

--- a/db/migrate/20240719171740_add_record_id_to_active_storage_attachments.rb
+++ b/db/migrate/20240719171740_add_record_id_to_active_storage_attachments.rb
@@ -1,0 +1,5 @@
+class AddRecordIdToActiveStorageAttachments < ActiveRecord::Migration[7.1]
+  def change
+    add_column :active_storage_attachments, :record_id, :bigint, null: false unless column_exists?(:active_storage_attachments, :record_id)
+  end
+end

--- a/db/migrate/20240720005706_create_profile_images.rb
+++ b/db/migrate/20240720005706_create_profile_images.rb
@@ -1,0 +1,8 @@
+class CreateProfileImages < ActiveRecord::Migration[7.1]
+  def change
+    create_table :profile_images do |t|
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_13_130933) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_20_005706) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
+    t.bigint "record_id", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|
@@ -51,6 +50,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_13_130933) do
     t.index ["user_id"], name: "index_plans_on_user_id"
   end
 
+  create_table "profile_images", force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_profile_images_on_user_id"
+  end
+
   create_table "spots", force: :cascade do |t|
     t.string "store_name", null: false
     t.text "introduction", null: false
@@ -78,5 +84,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_13_130933) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "plans", "users"
+  add_foreign_key "profile_images", "users"
   add_foreign_key "spots", "plans"
 end


### PR DESCRIPTION
プロフィール画像周りの実装を修正した。
userとplan,spotのidの型が異なる影響でuser側の画像のみ紐付けができない問題があった。
この部分を改修するために新たにprofile_imagesというテーブルを作成し、ここにuser用のavatarを用意することで想定していた実装を実現することに成功した。
ER図は後ほど修正する。