### PR TITLE
アカウント削除機能の実装

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -59,7 +59,7 @@ class PlansController < ApplicationController
     if @plan
       redirect_to edit_plan_path(@plan)
     else
-      redirect_to root_path, alert: "No articles found."
+      redirect_to root_path, alert: "投稿がありません。"
     end
   end
 

--- a/app/views/plans/_edit_form.html.erb
+++ b/app/views/plans/_edit_form.html.erb
@@ -32,10 +32,18 @@
   </div>
 
   <h2 class='text-main-orange font-bold pt-3 mt-5 mb-0 mx-auto text-xl sm:text-center'>おすすめスポット</h2>
-
+  <div id='spot-fields-template' style='display: none'>
+    <%= f.fields_for :spots, Spot.new, child_index: 'new_spot' do |spot_fields| %>
+      <%= render 'spot_fields', f: spot_fields %>
+    <% end %>
+  </div>
   <%= f.fields_for :spots do |spot_fields| %>
     <%= render 'edit_spot_fields', f: spot_fields %>
   <% end %>
+  <div id='spots'></div>
+  <div class='text-center mt-10' id='add-spot'>
+    <i class="fa-solid fa-circle-plus fa-4x cursor-pointer" style="color: #3b98ff;"></i>
+  </div>
 
   <div class='pt-10 my-20 text-center'>
     <button class='btn bg-accent-blue text-white px-20 hover:bg-accent-blue hover:opacity-50'>

--- a/app/views/plans/_form.html.erb
+++ b/app/views/plans/_form.html.erb
@@ -2,7 +2,7 @@
   <div class='pt-10 sm:mx-32'>
     <%= f.label :title %>
     <label class='input flex items-center gap-2'>
-      <%= f.text_field :title, class: 'w-full', placeholder:'日帰り！阪ひとり旅' %>
+      <%= f.text_field :title, class: 'w-full', placeholder:'日帰り！大阪ひとり旅' %>
     </label>
   </div>
 

--- a/app/views/plans/_plan.html.erb
+++ b/app/views/plans/_plan.html.erb
@@ -5,12 +5,12 @@
       <%= link_to plan_path(plan) do %>
         <div class='flex'>
           <% if plan.thumbnail.present? %>
-            <%= image_tag plan.thumbnail, class: 'w-32 h-32 rounded-lg' %>
+            <%= image_tag plan.thumbnail, class: 'w-32 h-32 object-cover rounded-lg' %>
           <% else %>
             <%= image_tag('sample.jpeg', class: 'w-32 h-32 rounded-lg') %>
           <% end %>
           <div class='flex flex-col justify-between w-full h-32 ml-5 md:w-42 lg:w-48 mx-auto'>
-            <h2 class='text-main-orange font-bold'><%= plan.title %></h2>
+            <h2 class='text-main-orange font-bold'><%= truncate(plan.title, length: 20) %></h2>
             <div  class='text-right text-xs mb-3'>
               <span class='border-b border-gray-600'>詳しく見る →</span>
             </div>

--- a/app/views/plans/_spot_fields.html.erb
+++ b/app/views/plans/_spot_fields.html.erb
@@ -27,7 +27,7 @@
       <%= f.url_field :site_url %>
     </label>
   </div>
-  <div class='cursor-pointer remove-spot pt-5 text-right'>
+  <div class='cursor-pointer remove-spot pt-5 sm:mx-32 text-right'>
     <i class='fa-solid fa-trash-can fa-lg ml-5' style='color: #ed7b7b;'></i>
   </div>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -17,7 +17,7 @@
       <p class='pt-10 mb-10'>メールアドレスの変更はこちら →</p>
     <% end %>
     <div class='pt-10 mb-20'>
-      <%= link_to '退会する', '#', class: 'btn bg-custom-red text-white px-20 hover:bg-custom-red hover:opacity-50' %>
+      <%= link_to '退会する', user_registration_path(@user), data: { turbo_method: :delete, turbo_confirm: "今まで投稿も全て消えます。本当に退会しますか？" }, class: 'btn bg-custom-red text-white px-20 hover:bg-custom-red hover:opacity-50' %>
     </div>
   </div>
 </main>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -13,3 +13,5 @@ ja:
         address: 住所(任意)
         site_url: サイトURL(任意)
         image: 画像(任意)
+      profile_image:
+        avatar: プロフィール画像


### PR DESCRIPTION
## チケットへのリンク

http://localhost:3000/profile
http://localhost:3000/plans/:id/edit


## やったこと(issue番号も記述する)

- [x] #29 
- [x] 旅行プラン編集画面にもおすすめスポット入力フォームの追加機能を実装


## やらないこと

旅行プラン編集画面において、すでに投稿済みのおすすめスポットを削除する機能は実装していない。

## できるようになること（ユーザ目線）

プロフィール画面から退会ができるようになった。
実行するとDBからもユーザー情報および投稿したものも全て削除される。

## できなくなること（ユーザ目線）

なし

## 動作確認

ブラウザ上での動作確認済み

## その他

なし